### PR TITLE
Revamp navigation and typography

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,28 +1,10 @@
 main:
 
-  - title: "Contact"
-    url: ./#contact
-    right: true
+  - title: "Bio"
+    url: ./#about-me
 
   - title: "Research"
     url: ./research
-    right: true
 
-
-  #- title: "Services"
-  #  url: ./#services
-
-  #- title: "Talks"
-  #  url: ./#invited-talks
-
-  # - title: "Teaching"
-  #  url: ./#teaching
-
-  # - title: "Publications"
-  #   url: ./#publications
-
-  #- title: "News"
-  #  url: ./#news
-
-  - title: "Bio"
-    url: ./#about-me
+  - title: "Teaching"
+    url: ./#teaching

--- a/_sass/minimal-light.scss
+++ b/_sass/minimal-light.scss
@@ -1,6 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
-body { background-color: #fff; padding: 0px; font: 16.0px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
+@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap");
+body { background-color: #fff; padding: 0px; font: 18px/1.6 'Open Sans', sans-serif; color: #444; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 
@@ -60,11 +60,11 @@ papertitle { font-weight: 600; font-size: 100%; }
 
 #header .image.avatar { margin: 0 0 1em 0; width: 16.00em; }
 
-h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; }
+h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Montserrat', sans-serif; }
 
-h1 { font-weight: 500; color: #002D72; margin: 0 0 20px; }
+h1 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Montserrat', sans-serif; }
 
-h2 { color: #002D72; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; }
+h2 { color: #002D72; font-weight: 600; margin: 2px 0px 15px; font-family: 'Montserrat', sans-serif; font-size: 24px; }
 
 p, ul, ol, table, pre, dl { margin: 0 0 20px; }
 

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -30,6 +30,7 @@
     padding: 10px 9px;
     text-decoration: none;
     font-size: 17px;
+    font-family: "Montserrat", sans-serif;
   }
   
   /* Change the color of links on hover */
@@ -55,6 +56,7 @@
 
     .topnav a.normal {
         padding: 10px 5px;
+        font-family: "Montserrat", sans-serif;
     }
 
    }
@@ -128,6 +130,7 @@
       }
 
       .topnav a.normal {
+        font-family: "Montserrat", sans-serif;
         color: white;
         float: none;
         padding: 14px 16px;

--- a/index.md
+++ b/index.md
@@ -16,6 +16,5 @@ My research lies at the intersection of **macroeconomics** -- with a focus on un
 {% include_relative _includes/news.md %}
 
 {% include_relative _includes/WorkProgress.md %}
-<!-- {% include_relative _includes/publications.md %} -->
 {% include_relative _includes/teaching.md %}
 {% include_relative _includes/contact.md %}

--- a/research.md
+++ b/research.md
@@ -2,5 +2,4 @@
 layout: homepage
 ---
 
-{% include_relative _includes/publications.md %}
 {% include_relative _includes/WorkProgress.md %}


### PR DESCRIPTION
## Summary
- streamline navigation so only Bio, Research, and Teaching remain
- remove publication include from research
- tidy index sections
- refresh fonts and larger text for improved looks

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aec18385c832d90a9d4006eb88229