### PR TITLE
Adjust base font size and restore fonts

### DIFF
--- a/_sass/minimal-light.scss
+++ b/_sass/minimal-light.scss
@@ -1,6 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap");
-body { background-color: #fff; padding: 0px; font: 18px/1.6 'Open Sans', sans-serif; color: #444; margin: 0; }
+@import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
+body { background-color: #fff; padding: 0px; font: 15px/1.5 'Crimson Pro', serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 
@@ -60,11 +60,11 @@ papertitle { font-weight: 600; font-size: 100%; }
 
 #header .image.avatar { margin: 0 0 1em 0; width: 16.00em; }
 
-h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Montserrat', sans-serif; }
+h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h1 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Montserrat', sans-serif; }
+h1 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h2 { color: #002D72; font-weight: 600; margin: 2px 0px 15px; font-family: 'Montserrat', sans-serif; font-size: 24px; }
+h2 { color: #002D72; font-weight: 600; margin: 2px 0px 15px; font-family: 'Crimson Pro', serif; font-size: 24px; }
 
 p, ul, ol, table, pre, dl { margin: 0 0 20px; }
 

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -30,7 +30,7 @@
     padding: 10px 9px;
     text-decoration: none;
     font-size: 17px;
-    font-family: "Montserrat", sans-serif;
+    font-family: "Crimson Pro", serif;
   }
   
   /* Change the color of links on hover */
@@ -56,7 +56,7 @@
 
     .topnav a.normal {
         padding: 10px 5px;
-        font-family: "Montserrat", sans-serif;
+        font-family: "Crimson Pro", serif;
     }
 
    }
@@ -130,7 +130,7 @@
       }
 
       .topnav a.normal {
-        font-family: "Montserrat", sans-serif;
+        font-family: "Crimson Pro", serif;
         color: white;
         float: none;
         padding: 14px 16px;

--- a/html_source_file/assets/css/style-no-dark-mode.css
+++ b/html_source_file/assets/css/style-no-dark-mode.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
-body { background-color: #fff; padding: 0px; font: 16.0px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
+body { background-color: #fff; padding: 0px; font: 15px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 

--- a/html_source_file/assets/css/style.css
+++ b/html_source_file/assets/css/style.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
-body { background-color: #fff; padding: 0px; font: 16.0px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
+body { background-color: #fff; padding: 0px; font: 15px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 


### PR DESCRIPTION
## Summary
- use Crimson Pro/Ubuntu Mono fonts again
- decrease base font size from 16px to 15px
- replace remaining Montserrat declarations with Crimson Pro

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686aef977b18832da77343f69fbf8411