### PR TITLE
Adjust fonts and base CSS

### DIFF
--- a/_sass/minimal-light-ori.scss
+++ b/_sass/minimal-light-ori.scss
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
-body { background-color: #fff; padding: 0px; font: 16.0px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
+body { background-color: #fff; padding: 0px; font: 15px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 
@@ -67,11 +67,11 @@ papertitle { font-weight: 600; font-size: 100%; }
 
 #header .image.avatar { margin: 0 0 1em 0; width: 16.00em; }
 
-h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; }
+h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h1 { font-weight: 500; color: #002D72; margin: 0 0 20px; }
+h1 { font-weight: 500; color: #002D72; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h2 { color: #002D72; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; }
+h2 { color: #002D72; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; font-family: 'Crimson Pro', serif; }
 
 @media (prefers-color-scheme: dark) { h1, h3, h4, h5, h6 { color: #3eb7f0; } h2 { color: #3eb7f0; } }
 
@@ -95,7 +95,7 @@ a:hover small { color: #777; }
 
 blockquote { border-left: 1px solid #e5e5e5; margin: 0; padding: 0 0 0 20px; font-style: italic; }
 
-code, pre { font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace; color: #333; }
+code, pre { font-family: "Ubuntu Mono", monospace; color: #333; }
 
 pre { max-width: 500px; padding: 8px 15px; background: #f8f8f8; border-radius: 5px; border: 1px solid #e5e5e5; overflow-x: auto; }
 
@@ -155,6 +155,6 @@ footer { width: 232px; float: left; position: fixed; bottom: 30px; -webkit-font-
 
 .fakelink { text-decoration: none; cursor: pointer; }
 
-.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: monospace; }
+.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: "Ubuntu Mono", monospace; }
 
 /*# sourceMappingURL=style.css.map */

--- a/_sass/minimal-light.scss
+++ b/_sass/minimal-light.scss
@@ -1,6 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap");
-body { background-color: #fff; padding: 0px; font: 18px/1.6 'Open Sans', sans-serif; color: #444; margin: 0; }
+@import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
+body { background-color: #fff; padding: 0px; font: 15px/1.5 'Crimson Pro', serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 
@@ -60,11 +60,11 @@ papertitle { font-weight: 600; font-size: 100%; }
 
 #header .image.avatar { margin: 0 0 1em 0; width: 16.00em; }
 
-h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Montserrat', sans-serif; }
+h3, h4, h5, h6 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h1 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Montserrat', sans-serif; }
+h1 { font-weight: 600; color: #002D72; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h2 { color: #002D72; font-weight: 600; margin: 2px 0px 15px; font-family: 'Montserrat', sans-serif; font-size: 24px; }
+h2 { color: #002D72; font-weight: 600; margin: 2px 0px 15px; font-family: 'Crimson Pro', serif; font-size: 24px; }
 
 p, ul, ol, table, pre, dl { margin: 0 0 20px; }
 
@@ -84,7 +84,7 @@ a:hover small { color: #777; }
 
 blockquote { border-left: 1px solid #e5e5e5; margin: 0; padding: 0 0 0 20px; font-style: italic; }
 
-code, pre { font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace; color: #333; }
+code, pre { font-family: "Ubuntu Mono", monospace; color: #333; }
 
 pre { max-width: 500px; padding: 8px 15px; background: #f8f8f8; border-radius: 5px; border: 1px solid #e5e5e5; overflow-x: auto; }
 
@@ -140,6 +140,6 @@ footer { width: 232px; float: left; position: fixed; bottom: 30px; -webkit-font-
 
 .fakelink { text-decoration: none; cursor: pointer; }
 
-.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: monospace; }
+.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: "Ubuntu Mono", monospace; }
 
 /*# sourceMappingURL=style.css.map */

--- a/assets/css/nav-ori.css
+++ b/assets/css/nav-ori.css
@@ -21,6 +21,7 @@
     padding: 18px 9px;
     text-decoration: none;
     font-size: 17px;
+    font-family: "Crimson Pro", serif;
   }
   
   /* Change the color of links on hover */
@@ -44,9 +45,10 @@
         margin-right:3%;
       }
 
-    .topnav a {
-        padding: 18px 5px;
-    }
+      .topnav a {
+          padding: 18px 5px;
+          font-family: "Crimson Pro", serif;
+      }
 
    }
 

--- a/assets/css/nav.css
+++ b/assets/css/nav.css
@@ -30,7 +30,7 @@
     padding: 10px 9px;
     text-decoration: none;
     font-size: 17px;
-    font-family: "Montserrat", sans-serif;
+    font-family: "Crimson Pro", serif;
   }
   
   /* Change the color of links on hover */
@@ -56,7 +56,7 @@
 
     .topnav a.normal {
         padding: 10px 5px;
-        font-family: "Montserrat", sans-serif;
+        font-family: "Crimson Pro", serif;
     }
 
    }
@@ -130,7 +130,7 @@
       }
 
       .topnav a.normal {
-        font-family: "Montserrat", sans-serif;
+        font-family: "Crimson Pro", serif;
         color: white;
         float: none;
         padding: 14px 16px;

--- a/html_source_file/assets/css/style-no-dark-mode.css
+++ b/html_source_file/assets/css/style-no-dark-mode.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
-body { background-color: #fff; padding: 0px; font: 16.0px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
+body { background-color: #fff; padding: 0px; font: 15px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 
@@ -62,11 +62,11 @@ papertitle { font-weight: 600; font-size: 100%; }
 
 #header .image.avatar { margin: 0 0 1em 0; width: 8.00em; }
 
-h3, h4, h5, h6 { font-weight: 600; color: #043361; margin: 0 0 20px; }
+h3, h4, h5, h6 { font-weight: 600; color: #043361; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h1 { font-weight: 500; color: #043361; margin: 0 0 20px; }
+h1 { font-weight: 500; color: #043361; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h2 { color: #043361; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; }
+h2 { color: #043361; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; font-family: 'Crimson Pro', serif; }
 
 p, ul, ol, table, pre, dl { margin: 0 0 20px; }
 
@@ -86,7 +86,7 @@ a:hover small { color: #777; }
 
 blockquote { border-left: 1px solid #e5e5e5; margin: 0; padding: 0 0 0 20px; font-style: italic; }
 
-code, pre { font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace; color: #333; }
+code, pre { font-family: "Ubuntu Mono", monospace; color: #333; }
 
 pre { max-width: 500px; padding: 8px 15px; background: #f8f8f8; border-radius: 5px; border: 1px solid #e5e5e5; overflow-x: auto; }
 
@@ -156,4 +156,4 @@ footer { width: 232px; float: left; position: fixed; bottom: 30px; -webkit-font-
 
 .fakelink { text-decoration: none; cursor: pointer; }
 
-.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: monospace; }
+.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: "Ubuntu Mono", monospace; }

--- a/html_source_file/assets/css/style.css
+++ b/html_source_file/assets/css/style.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,500;0,600;1,500;1,600&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap");
-body { background-color: #fff; padding: 0px; font: 16.0px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
+body { background-color: #fff; padding: 0px; font: 15px/1.5 Crimson Pro, serif; color: #595959; font-weight: 400; margin: 0; }
 
 .pub-row { display: flex; align-items: center; }
 
@@ -71,11 +71,11 @@ papertitle { font-weight: 600; font-size: 100%; }
 
 #header .image.avatar { margin: 0 0 1em 0; width: 8.00em; }
 
-h3, h4, h5, h6 { font-weight: 600; color: #043361; margin: 0 0 20px; }
+h3, h4, h5, h6 { font-weight: 600; color: #043361; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h1 { font-weight: 500; color: #043361; margin: 0 0 20px; }
+h1 { font-weight: 500; color: #043361; margin: 0 0 20px; font-family: 'Crimson Pro', serif; }
 
-h2 { color: #043361; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; }
+h2 { color: #043361; font-weight: 500; margin: 2px 0px 15px; font-size: 157%; font-family: 'Crimson Pro', serif; }
 
 @media (prefers-color-scheme: dark) { h1, h3, h4, h5, h6 { color: #3eb7f0; }
   h2 { color: #3eb7f0; } }
@@ -98,7 +98,7 @@ a:hover small { color: #777; }
 
 blockquote { border-left: 1px solid #e5e5e5; margin: 0; padding: 0 0 0 20px; font-style: italic; }
 
-code, pre { font-family: Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, Consolas, Liberation Mono, DejaVu Sans Mono, Courier New, monospace; color: #333; }
+code, pre { font-family: "Ubuntu Mono", monospace; color: #333; }
 
 pre { max-width: 500px; padding: 8px 15px; background: #f8f8f8; border-radius: 5px; border: 1px solid #e5e5e5; overflow-x: auto; }
 
@@ -171,4 +171,4 @@ footer { width: 232px; float: left; position: fixed; bottom: 30px; -webkit-font-
 
 .fakelink { text-decoration: none; cursor: pointer; }
 
-.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: monospace; }
+.bibref { font-size: 70%; margin-top: 10px; margin-left: 0px; display: none; font-family: "Ubuntu Mono", monospace; }


### PR DESCRIPTION
## Summary
- use Ubuntu Mono for code snippets and references
- set heading fonts to Crimson Pro in compiled styles
- update base SASS with same fonts and smaller 15px body size
- tweak navigation CSS template with Crimson Pro

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686aef977b18832da77343f69fbf8411